### PR TITLE
Fix a bug in function download_url.

### DIFF
--- a/ofa/utils.py
+++ b/ofa/utils.py
@@ -188,6 +188,8 @@ def download_url(url, model_dir='~/.torch/', overwrite=False):
                 # If fail, then ensure the lock is removed so download can be executed next time.
                 print("Failed to download from url %s" % url + "\n" + str(e) + "\n")
                 return str(e)
+            
+    return filepath
 
 
 


### PR DESCRIPTION
Fix a bug in function download_url.
It should return the filepath if the file has already been downloaded, otherwise the function would return None. 
Then, an error would be occurred.