### PR TITLE
Modify round to support tracing

### DIFF
--- a/ofa/imagenet_classification/elastic_nn/modules/dynamic_layers.py
+++ b/ofa/imagenet_classification/elastic_nn/modules/dynamic_layers.py
@@ -42,6 +42,13 @@ __all__ = [
 ]
 
 
+def round(x):
+    if isinstance(x, torch.Tensor):
+        
+        return torch.round(x.float())
+    else:
+        return torch.round(torch.tensor(x, dtype=torch.float))
+    
 def adjust_bn_according_to_idx(bn, idx):
     bn.weight.data = torch.index_select(bn.weight.data, 0, idx)
     bn.bias.data = torch.index_select(bn.bias.data, 0, idx)


### PR DESCRIPTION
Upon calling model tracing:
```python
from ofa.model_zoo import ofa_net

ofa_network = ofa_net("ofa_mbv3_d234_e346_k357_w1.0", pretrained=True)
traced_model = torch.jit.trace(ofa_network, torch.randn(1, 3, 224, 224))
```

I run into the following error: 
```bash
once-for-all/ofa/imagenet_classification/elastic_nn/modules/dynamic_layers.py in forward(self, x)
    225         if self.inverted_bottleneck is not None:
    226             self.inverted_bottleneck.conv.active_out_channel = make_divisible(
--> 227                 round(in_channel * self.active_expand_ratio),
    228                 MyNetwork.CHANNEL_DIVISIBLE,
    229             )

TypeError: type Tensor doesn't define __round__ method
```
I replaced `round` with `torch.round`. 

Thanks
Maulik